### PR TITLE
Update websphere-liberty short description

### DIFF
--- a/open-liberty/README-short.txt
+++ b/open-liberty/README-short.txt
@@ -1,1 +1,1 @@
-Open Liberty multi-architecture images based on Ubuntu 18.04
+Open Liberty multi-architecture images based on Ubuntu

--- a/websphere-liberty/README-short.txt
+++ b/websphere-liberty/README-short.txt
@@ -1,1 +1,1 @@
-WebSphere Liberty multi-architecture images based on Ubuntu 18.04
+WebSphere Liberty multi-architecture images based on Ubuntu


### PR DESCRIPTION
The reference to Ubuntu 18.04 is outdated, hence remove it.